### PR TITLE
Disallow playing > 3 cards in a round

### DIFF
--- a/lib/native/card.ml
+++ b/lib/native/card.ml
@@ -3,6 +3,18 @@ type t =
   | Property of Property.card
   | Action of Action.t
 
+module Used = struct
+  type t =
+    | Money of Money.t
+    | Property of Property.t
+    (* TODO: Add additional state for action cards.
+       Below are a few states that will be important.
+       - Color chosen for a rent card
+       - Amount of rent
+       - The property a hotel card was used on *)
+    | Action of Action.t
+end
+
 let money value = Money value
 let simple_property color = Property (Simple color)
 let dual_property colors = Property (Dual colors)

--- a/lib/native/property.ml
+++ b/lib/native/property.ml
@@ -22,3 +22,19 @@ let use_simple color = Simple color
 let use_dual colors choice = Dual (colors, choice)
 let use_wild _ color = Wild color
 let wild : card = Wild ()
+let ( let* ) = Result.bind
+
+let use ?color (card : card) =
+  match card with
+  | Simple color -> Ok (use_simple color)
+  | Dual dual ->
+      let* color = Option.to_result ~none:`Missing_color color in
+      let* choice =
+        match dual with
+        | l, _ when l = color -> Ok Dual.L
+        | _, r when r = color -> Ok Dual.R
+        | _ -> Error `Invalid_color
+      in
+      Ok (use_dual dual choice)
+  | Wild w ->
+      color |> Option.to_result ~none:`Missing_color |> Result.map (use_wild w)

--- a/lib/native/property.mli
+++ b/lib/native/property.mli
@@ -15,7 +15,7 @@ type t =
   | Wild of Color.t
 
 val color : t -> Color.t
-val use_simple : simple -> t
-val use_dual : Dual.t -> Dual.choice -> t
-val use_wild : wild -> Color.t -> t
 val wild : card
+
+val use :
+  ?color:Color.t -> card -> (t, [> `Invalid_color | `Missing_color ]) result

--- a/test/test_fortune.ml
+++ b/test/test_fortune.ml
@@ -45,6 +45,10 @@ let%expect_test "default game" =
 
 
 
+    This turn -
+
+
+
     86 card(s) left in the deck.
 
     []
@@ -73,6 +77,10 @@ let%expect_test "play simple property cards" =
 
 
 
+    This turn -
+
+
+
     86 card(s) left in the deck.
 
     []
@@ -97,6 +105,11 @@ let%expect_test "play simple property cards" =
 
     0. BROWN
     1. BLUE
+
+    This turn -
+
+    BROWN
+    BLUE
 
     86 card(s) left in the deck.
 
@@ -124,12 +137,16 @@ let%expect_test "play a money card" =
 
 
 
+    This turn -
+
+    M4
+
     86 card(s) left in the deck.
 
     []
     |}]
 
-let%expect_test "play an action card as money" =
+let%expect_test "play action cards as money" =
   default_game |> exec (4, AsMoney) |> exec (3, AsMoney) |> render;
   [%expect
     {|
@@ -149,6 +166,11 @@ let%expect_test "play an action card as money" =
     Properties -
 
 
+
+    This turn -
+
+    M1 (PASS GO)
+    M4 (JUST SAY NO)
 
     86 card(s) left in the deck.
 
@@ -174,6 +196,10 @@ let%expect_test "display error on trying to play property card as money" =
 
 
     Properties -
+
+
+
+    This turn -
 
 
 
@@ -203,6 +229,10 @@ let%expect_test "play wild property - first color" =
 
     0. [SKYBLUE] BROWN
 
+    This turn -
+
+    [SKYBLUE] BROWN
+
     86 card(s) left in the deck.
 
     []
@@ -229,6 +259,10 @@ let%expect_test "play wild property - second color" =
 
     0. SKYBLUE [BROWN]
 
+    This turn -
+
+    SKYBLUE [BROWN]
+
     86 card(s) left in the deck.
 
     []
@@ -253,6 +287,10 @@ let%expect_test "play wild property with a wrong color" =
 
 
     Properties -
+
+
+
+    This turn -
 
 
 
@@ -284,6 +322,10 @@ let%expect_test "play very wild card" =
 
 
 
+    This turn -
+
+
+
     86 card(s) left in the deck.
 
     []
@@ -308,7 +350,46 @@ let%expect_test "play very wild card" =
 
     0. BLACK [WILD]
 
+    This turn -
+
+    BLACK [WILD]
+
     86 card(s) left in the deck.
 
     []
     |}]
+
+  let%expect_test "disallow playing more than 3 cards" =
+    default_game
+    |> exec (0, WithColor SkyBlue)
+    |> exec (0, Self)
+    |> exec (1, AsMoney)
+    |> exec (1, AsMoney)
+    |> render;
+    [%expect {|
+      ocaml
+
+      Hand -
+
+      0. RENT: BROWN SKYBLUE
+      1. JUST SAY NO
+
+      Bank -
+
+      0. M1 (PASS GO)
+      1. M4
+
+      Properties -
+
+      0. [SKYBLUE] BROWN
+
+      This turn -
+
+      M1 (PASS GO)
+      M4
+      [SKYBLUE] BROWN
+
+      86 card(s) left in the deck.
+
+      [You can't play more than 3 cards in a round.]
+      |}]

--- a/test/test_fortune.ml
+++ b/test/test_fortune.ml
@@ -359,14 +359,15 @@ let%expect_test "play very wild card" =
     []
     |}]
 
-  let%expect_test "disallow playing more than 3 cards" =
-    default_game
-    |> exec (0, WithColor SkyBlue)
-    |> exec (0, Self)
-    |> exec (1, AsMoney)
-    |> exec (1, AsMoney)
-    |> render;
-    [%expect {|
+let%expect_test "disallow playing more than 3 cards" =
+  default_game
+  |> exec (0, WithColor SkyBlue)
+  |> exec (0, Self)
+  |> exec (1, AsMoney)
+  |> exec (1, AsMoney)
+  |> render;
+  [%expect
+    {|
       ocaml
 
       Hand -

--- a/tui/command.ml
+++ b/tui/command.ml
@@ -31,6 +31,7 @@ let message = function
   | `Invalid_color -> "You can't play that card with that color."
   | `Missing_color -> "You need to specify a color to play that card."
   | `Not_a_property -> "You can't play that card as a property."
+  | `Moves_over -> "You can't play more than 3 cards in a round."
 
 let exec Ui.{ game; _ } (n, play) =
   let next =

--- a/tui/ui.ml
+++ b/tui/ui.ml
@@ -137,14 +137,27 @@ Properties -
         (show_properties properties)
   end
 
+  let show_used cards =
+    cards
+    |> List.map (function
+         | Fortune.Card.Used.Property p -> Property.show p
+         | Action a -> Action.show a
+         | Money m -> Money.show m)
+    |> String.concat "\n"
+
   let show { game; error_message } =
     Printf.sprintf {|%s
+
+This turn -
+
+%s
 
 %d card(s) left in the deck.
 
 [%s]
 |}
       (game |> Fortune.Game.current_player |> Player.show)
+      (show_used game.played_cards)
       (Fortune.Deck.count game.draw_pile)
       (error_message |> Option.value ~default:"")
 


### PR DESCRIPTION
- Creates a new type to store played cards in the game to display in the current round status
- Updates `Game.t` to hold cards played in the current round
- Adds a function to check whether the player's moves are over for the round
- Updates tests to account for the new text box
- Adds a test for the error shown when a player tries to play a 4th card